### PR TITLE
Update project settings for Xcode 11 and iOS 11

### DIFF
--- a/NSObject-SafeExpectations.podspec
+++ b/NSObject-SafeExpectations.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "NSObject-SafeExpectations"
-  s.version      = "0.0.4-beta.1"
+  s.version      = "0.0.4"
   s.summary      = "No more crashes getting unexpected values from a NSDictionary."
   s.homepage     = "https://github.com/wordpress-mobile/NSObject-SafeExpectations"
   s.license      = { :type => 'MIT', :file => 'LICENSE' }

--- a/NSObject-SafeExpectations.podspec
+++ b/NSObject-SafeExpectations.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name         = "NSObject-SafeExpectations"
-  s.version      = "0.0.3"
+  s.version      = "0.0.4-beta.1"
   s.summary      = "No more crashes getting unexpected values from a NSDictionary."
   s.homepage     = "https://github.com/wordpress-mobile/NSObject-SafeExpectations"
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.authors      = { "Jorge Bernal" => "jbernal@gmail.com", "Aaron Douglas" => "astralbodies@gmail.com" }
   s.source       = { :git => "https://github.com/wordpress-mobile/NSObject-SafeExpectations.git", :tag => s.version.to_s }
   s.source_files = 'Sources/*.{h,m}'
-  s.platform     = :ios, "8.0"
+  s.platform     = :ios, "11.0"
   s.requires_arc = true
 end

--- a/NSObject-SafeExpectations.xcodeproj/project.pbxproj
+++ b/NSObject-SafeExpectations.xcodeproj/project.pbxproj
@@ -11,8 +11,6 @@
 		E1A598191CAAC1CC0047815E /* NSDictionary+SafeExpectations.h in Headers */ = {isa = PBXBuildFile; fileRef = E1A598111CAAC1CC0047815E /* NSDictionary+SafeExpectations.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E1A5981A1CAAC1CC0047815E /* NSDictionary+SafeExpectations.m in Sources */ = {isa = PBXBuildFile; fileRef = E1A598121CAAC1CC0047815E /* NSDictionary+SafeExpectations.m */; };
 		E1A5981B1CAAC1CC0047815E /* SafeExpectations.h in Headers */ = {isa = PBXBuildFile; fileRef = E1A598131CAAC1CC0047815E /* SafeExpectations.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E1A5981C1CAAC1CC0047815E /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E1A598151CAAC1CC0047815E /* Info.plist */; };
-		E1A5981F1CAAC1D40047815E /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E1A598171CAAC1CC0047815E /* Info.plist */; };
 		E1A598201CAAC1D80047815E /* SafeExpectationsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E1A598181CAAC1CC0047815E /* SafeExpectationsTests.m */; };
 		E1A598211CAAC1F30047815E /* NSDictionary+SafeExpectations.h in Headers */ = {isa = PBXBuildFile; fileRef = E1A598111CAAC1CC0047815E /* NSDictionary+SafeExpectations.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E1A598221CAAC1F30047815E /* NSDictionary+SafeExpectations.m in Sources */ = {isa = PBXBuildFile; fileRef = E1A598121CAAC1CC0047815E /* NSDictionary+SafeExpectations.m */; };
@@ -202,7 +200,7 @@
 		E1A597D11CAABEBF0047815E /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0730;
+				LastUpgradeCheck = 1130;
 				TargetAttributes = {
 					E1A597DB1CAABEFB0047815E = {
 						CreatedOnToolsVersion = 7.3;
@@ -217,10 +215,11 @@
 			};
 			buildConfigurationList = E1A597D41CAABEBF0047815E /* Build configuration list for PBXProject "NSObject-SafeExpectations" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = E1A597D01CAABEBF0047815E;
 			productRefGroup = E1A597DD1CAABEFB0047815E /* Products */;
@@ -239,7 +238,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E1A5981C1CAAC1CC0047815E /* Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -254,7 +252,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E1A5981F1CAAC1D40047815E /* Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -299,12 +296,66 @@
 		E1A597D51CAABEBF0047815E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				ONLY_ACTIVE_ARCH = YES;
 			};
 			name = Debug;
 		};
 		E1A597D61CAABEBF0047815E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
 			};
 			name = Release;
 		};

--- a/NSObject-SafeExpectations.xcodeproj/xcshareddata/xcschemes/SafeExpectations-Mac.xcscheme
+++ b/NSObject-SafeExpectations.xcodeproj/xcshareddata/xcschemes/SafeExpectations-Mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E1A597F81CAABF200047815E"
+            BuildableName = "SafeExpectations.framework"
+            BlueprintName = "SafeExpectations-Mac"
+            ReferencedContainer = "container:NSObject-SafeExpectations.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "E1A597F81CAABF200047815E"
-            BuildableName = "SafeExpectations.framework"
-            BlueprintName = "SafeExpectations-Mac"
-            ReferencedContainer = "container:NSObject-SafeExpectations.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -70,8 +68,6 @@
             ReferencedContainer = "container:NSObject-SafeExpectations.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/NSObject-SafeExpectations.xcodeproj/xcshareddata/xcschemes/SafeExpectations-iOS.xcscheme
+++ b/NSObject-SafeExpectations.xcodeproj/xcshareddata/xcschemes/SafeExpectations-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E1A597DB1CAABEFB0047815E"
+            BuildableName = "SafeExpectations.framework"
+            BlueprintName = "SafeExpectations-iOS"
+            ReferencedContainer = "container:NSObject-SafeExpectations.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "E1A597DB1CAABEFB0047815E"
-            BuildableName = "SafeExpectations.framework"
-            BlueprintName = "SafeExpectations-iOS"
-            ReferencedContainer = "container:NSObject-SafeExpectations.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -70,8 +68,6 @@
             ReferencedContainer = "container:NSObject-SafeExpectations.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
##### Change log

- Update podspec to version 0.0.4-beta.1, update iOS platform version to 11.0
- Update shared schemes to recommended settings
- Update project ro recommended settings, localization and internationalization