### PR TITLE
[Tooling] Standardize podspec format

### DIFF
--- a/NSObject-SafeExpectations.podspec
+++ b/NSObject-SafeExpectations.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
 
   s.homepage      = "https://github.com/wordpress-mobile/NSObject-SafeExpectations"
   s.license       = { :type => 'MIT', :file => 'LICENSE' }
-  s.author        = { "The WordPress Mobile Team" => "mobile@automattic.com" }
+  s.author        = { "The WordPress Mobile Team" => "mobile@wordpress.org" }
 
   s.platform      = :ios, "11.0"
   

--- a/NSObject-SafeExpectations.podspec
+++ b/NSObject-SafeExpectations.podspec
@@ -1,12 +1,19 @@
 Pod::Spec.new do |s|
-  s.name         = "NSObject-SafeExpectations"
-  s.version      = "0.0.4"
-  s.summary      = "No more crashes getting unexpected values from a NSDictionary."
-  s.homepage     = "https://github.com/wordpress-mobile/NSObject-SafeExpectations"
-  s.license      = { :type => 'MIT', :file => 'LICENSE' }
-  s.authors      = { "Jorge Bernal" => "jbernal@gmail.com", "Aaron Douglas" => "astralbodies@gmail.com" }
-  s.source       = { :git => "https://github.com/wordpress-mobile/NSObject-SafeExpectations.git", :tag => s.version.to_s }
-  s.source_files = 'Sources/*.{h,m}'
-  s.platform     = :ios, "11.0"
-  s.requires_arc = true
+  s.name          = "NSObject-SafeExpectations"
+  s.version       = "0.0.4"
+
+  s.summary       = "No more crashes getting unexpected values from a NSDictionary."
+  s.description   = <<-DESC
+                    This micro-library exposes an NSDictionary category which ensures that the value for the queried key is of the expected type before returning it (and returns nil otherwise).
+                    This ensures we don't get unexpected types when looking up values from our NSDictionary which would lead to runtime crashes.
+                  DESC
+
+  s.homepage      = "https://github.com/wordpress-mobile/NSObject-SafeExpectations"
+  s.license       = { :type => 'MIT', :file => 'LICENSE' }
+  s.author        = { "The WordPress Mobile Team" => "mobile@automattic.com" }
+
+  s.platform      = :ios, "11.0"
+  
+  s.source        = { :git => "https://github.com/wordpress-mobile/NSObject-SafeExpectations.git", :tag => s.version.to_s }
+  s.source_files  = 'Sources/*.{h,m}'
 end


### PR DESCRIPTION
As part of paaHJt-Vl-p2, this simply standardize the podspec file so that all our pods use a similar format and structure, with similar keys and common values.

See wordpress-mobile/WordPressAuthenticator-iOS#582 for the rules I decided to follow on the format and content standardization.